### PR TITLE
Follow-up Feedback

### DIFF
--- a/guidelines/guideline-ci2.html
+++ b/guidelines/guideline-ci2.html
@@ -240,7 +240,7 @@
 
         <h2 id="occurences">Suggestion (WHAT)</h2>
 
-        <p>The development team should identify security or privacy vulnerabilities that may pose a risk to participants' integrity, confidentiality, and availability, that may be caused by the testing and runtime verification activities. The ros-security workgroup, in collaboration with Alias Robotics, maintains SROS (git: ros2/sros2) for the analysis of such vulnerabilities and fixes. In addition, Alias Robotics maintains a database of vulnerabilities detected in ROS applications (git: aliasrobotics/RVD) as a means of awareness.</p>
+        <p>The development team should identify security or privacy vulnerabilities that may pose a risk to participants' integrity, confidentiality, and availability, that may be caused by the testing and runtime verification activities. The ros-security workgroup maintains SROS (git: ros2/sros2) for the analysis of such vulnerabilities and fixes. In addition, Alias Robotics maintains a database of vulnerabilities detected in ROS applications (git: aliasrobotics/RVD) as a means of awareness.</p>
 
 
         <h2>Process (HOW)</h2>
@@ -274,7 +274,7 @@ In addition, the ros-security working group, in tandem with Alias Robotics, work
 
 
         <p class="weaknesses" style="text-indent: 25px;">Weaknesses:</p>
-        <p> The guideline, intentionally, does not provide specific details on how to implement security and privacy constraints, leaving it up to the developers to decide which constraints are necessary and how to enforce them, since this is domain-dependent. It may be challenging to understand the various security vulnerabilities associated with ROS-based applications, making it difficult to specify appropriate security and privacy constraints. The guideline may require additional time and resources to implement security and privacy constraints, which may delay the development process.
+        <p> The guideline, intentionally, does not provide specific details on how to implement security and privacy constraints, leaving it up to the developers to decide which constraints are necessary and how to enforce them, since this is domain-dependent. It may be challenging to understand the various security vulnerabilities associated with ROS-based applications, making it difficult to specify appropriate security and privacy constraints. The guideline may require additional time and resources to implement security and privacy constraints, which may delay the development process. Systems with lower technology readiness level, such as academic prototypes, may not need a thorough security assessment, making this guideline irrelevant in those cases.
         </p>
 
 

--- a/guidelines/guideline-mta2.html
+++ b/guidelines/guideline-mta2.html
@@ -289,7 +289,7 @@
 
         <p class="weaknesses" style="text-indent: 25px;">Weaknesses:</p>
         <p>
-          There is a high initial investment of time and resources. There is also a maintenance overhead related to maintaining the automation machinery when the system evolves. 
+          There is a high initial investment of time and resources. There is also a maintenance overhead related to maintaining the automation machinery when the system evolves. Test generation may not scale for complex scenarios.
         </p>
 
 

--- a/guidelines/guideline-pe2.html
+++ b/guidelines/guideline-pe2.html
@@ -271,7 +271,7 @@
 
         <p class="weaknesses" style="text-indent: 25px;">Weaknesses:</p>
         <p>
-          Models need to be updated and maintained as the system evolves, which can be a costly and time-consuming task. In addition, modeling can be prone to errors and inaccuracies, which can affect the quality of the testing results. Models are domain dependent and may not be easily transferrable between domains such as healthcare domain, automotive, or aerial domains. 
+          Large and complex robotics systems may impair the creation and maintenance of runtime models. Models need to be updated and maintained as the system evolves, which can be a costly and time-consuming task. In addition, modeling can be prone to errors and inaccuracies, which can affect the quality of the testing results. Models are domain dependent and may not be easily transferrable between domains such as healthcare domain, automotive, or aerial domains. 
         </p>
 
 


### PR DESCRIPTION
This update modifies the guidelines CI2, MTA2, and PE2 to include the comments from experts during the questionnaire's follow-up.

Changes:
- Fixed the role of AliasRobotics in maintaining SROS. (CI2)
- Added statements to the weaknesses' of CI2, MTA2, and PE2, delimiting the scope in which the guideline may assist developers and QA teams rather than impair their work.