### PR TITLE
Add R2D2 and ROFER fuzzers to MTA1 guideline

### DIFF
--- a/guidelines/guideline-mta1.html
+++ b/guidelines/guideline-mta1.html
@@ -236,7 +236,11 @@
         <h4 style="text-indent: 25px;">Noise Injection</h4>
 
         <p>
-          With the goal of effectively stressing a data-driven ROS system, Seulbae Kim et al. [3] implemented RoboFuzz <a href="https://github.com/sslab-gatech/RoboFuzz">(RoboFuzz)</a>, which is based on a data type-aware mutation technique aimed at finding correctness bugs in the system. RoboFuzz takes a target system and a test strategy as input and outputs the report of found bugs after performing a fuzzing technique based on message mutation. In addition, RosPenTo [6]  <a href="https://github.com/jr-robotics/ROSPenTo">(jr-robotics/ROSPenTo)</a> provides the operations of unregistering and registering publishers/subscribers, isolating nodes and services, and injecting false data in messages. As an example, the authors show how to use the tool to isolate the safety monitor node and to inject fault data in a robotic operation in such a way that the robot may harm humans [6]. 
+          With the goal of effectively stressing a data-driven ROS system, Seulbae Kim et al. [3] implemented RoboFuzz <a href="https://github.com/sslab-gatech/RoboFuzz">(RoboFuzz)</a>, which is based on a data type-aware mutation technique aimed at finding correctness bugs in the system. RoboFuzz takes a target system and a test strategy as input and outputs the report of found bugs after performing a fuzzing technique based on message mutation. In addition, RosPenTo [6]  <a href="https://github.com/jr-robotics/ROSPenTo">(jr-robotics/ROSPenTo)</a> provides the operations of unregistering and registering publishers/subscribers, isolating nodes and services, and injecting false data in messages. As an example, the authors show how to use the tool to isolate the safety monitor node and to inject fault data in a robotic operation in such a way that the robot may harm humans [6].
+        </p>
+
+        <p>
+          More recently, R2D2 [7] advances ROS 2 fuzzing by leveraging the system's runtime states as guidance. Unlike prior fuzzers that rely on code coverage alone, R2D2 instruments the ROS 2 middleware to capture callback traces in real-time, profiling the current system state to guide input generation towards unexplored state space. In evaluation on four ROS 2 applications, R2D2 achieved 3.91x and 2.56x improvement in code coverage compared to Ros2Fuzz and RoboFuzz respectively, and uncovered 39 previously unknown vulnerabilities. Similarly, ROFER [8] introduces dimension-level mutation that considers each input dimension's contribution to coverage, combined with a message-guided fuzzing approach using a novel coverage metric based on message features. ROFER was evaluated on 13 ROS 2 programs and found 88 real bugs, 46 confirmed by ROS developers.
         </p>
 
         <h4 style="text-indent: 25px;">Fault Injection</h4>
@@ -269,6 +273,8 @@
               <p>[4] U. Yayan and C. Baglum, “Tailored mutation-based software fault injection tool (im-fit),” SoftwareX, p. 101463, 2023.  </p>
                 <p>[5] Y.-S. Hsiao, Z. Wan et al., “Mavfi: An end-to-end fault analysis framework with anomaly detection and recovery for micro aerial vehicles,” arXiv preprint arXiv:2105.12882, 2021.  </p>
                 <p>[6] B. Dieber, R. White et al., “Penetration testing ros,” Robot Operating System (ROS), p. 183, 2020. 3</p>
+                <p>[7] Y. Shen, H. Huang, J. Liu, Y. Jiang, and J. Bai, “Enhancing ROS System Fuzzing through Callback Tracing,” in Proceedings of the 33rd ACM SIGSOFT International Symposium on Software Testing and Analysis (ISSTA), 2024, pp. 763–778. </p>
+                <p>[8] J.-J. Bai, H.-X. Song, and S.-M. Hu, “Multi-dimensional and Message-Guided Fuzzing for Robotic Programs in Robot Operating System,” in Proceedings of the 29th ACM International Conference on Architectural Support for Programming Languages and Operating Systems (ASPLOS), vol. 2, 2024, pp. 763–778. </p>
 
         </blockquote>
 

--- a/index.html
+++ b/index.html
@@ -149,9 +149,9 @@
             <div style="border: 1px solid #ddd; border-radius: 6px; padding: 20px 24px; margin: 24px 0; background-color: #f9f9f9;">
               <h2 id="whats-new" style="margin-top: 0;">What's New</h2>
               <ul style="list-style: none; padding-left: 0;">
+                <li style="margin-bottom: 10px;"><strong>March 2026</strong> — New exemplars added: R2D2 and ROFER ROS 2 fuzzers for noise injection and robustness testing (<a href="guidelines/guideline-mta1">MTA1</a>).</li>
                 <li style="margin-bottom: 10px;"><strong>March 2026</strong> — Website refresh: updated contact info, copyright, and contribution guidelines.</li>
                 <li style="margin-bottom: 10px;"><strong>March 2026</strong> — New guideline tools coming soon: FRET + Copilot monitor generation pipeline, updated ROSMonitoring references, and more. <a href="https://github.com/ros-rvft/ros-rvft.github.io/issues">Follow progress on GitHub Issues</a>.</li>
-                <li style="margin-bottom: 10px;"><strong>July 2024</strong> — Initial release of the guideline catalog accompanying the TSE paper.</li>
               </ul>
             </div>
 


### PR DESCRIPTION
## What does this PR do?

Adds R2D2 (ISSTA 2024) and ROFER (ASPLOS 2024) as new exemplars in the Noise Injection subsection of MTA1. Both are recent ROS 2 fuzzers that advance beyond the existing RoboFuzz coverage — R2D2 via callback-trace- guided fuzzing and ROFER via dimension-level mutation with message-guided coverage. References are added. 

## Which guideline(s) does it affect?

MTA1 — Improve the robustness of the system by performing noise and fault injection

## Checklist

- [x] I followed the existing HTML structure and style (no new CSS files or frameworks).
- [x] The site renders correctly when I open the changed `.html` files locally.
- [x] My commit messages are descriptive (one concern per commit).