### PR TITLE
Fix _config.yml: include _pages dir and stop excluding replication

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,13 +24,16 @@ plugins:
   - jekyll-sitemap
   - jekyll-feed
 
+# Include directories that Jekyll ignores by default
+include:
+  - _pages
+
 # Exclude from processing
 exclude:
   - Gemfile
   - Gemfile.lock
   - LICENSE
   - README.md
-  - replication_package_extras
   - guideline_template.html
 
 # Footer


### PR DESCRIPTION
## What does this PR do?

Fixes two build configuration issues introduced during the Jekyll migration:

1. Added `include: ["_pages"]` to `_config.yml` — Jekyll ignores underscore-prefixed directories by default, which caused the evaluation, authors, contribute, replication, and research pages to return 404.

2. Removed `replication_package_extras` from the `exclude` list in `_config.yml` — this was preventing Jekyll from copying PDFs, CSVs, and other download files to the build output, breaking all download links on the replication page.

## Which guideline(s) does it affect?

General site update — no guideline content modified. Fixes affect the root-level pages (evaluation, authors, contribute, replication, research) and the replication package download links.

## Checklist

- [x] I followed the existing HTML structure and style (no new CSS files or frameworks).
- [x] The site renders correctly when I open the changed `.html` files locally.
- [x] My commit messages are descriptive (one concern per commit).