### PR TITLE
Fix redirects to target specific anchors on consolidated paper page

### DIFF
--- a/_pages/authors.md
+++ b/_pages/authors.md
@@ -1,0 +1,6 @@
+---
+permalink: /authors
+sitemap: false
+---
+<meta http-equiv="refresh" content="0; url=/paper#authors">
+<p>Redirecting to <a href="/paper#authors">About the Paper — Authors</a>...</p>

--- a/_pages/evaluation.md
+++ b/_pages/evaluation.md
@@ -1,0 +1,6 @@
+---
+permalink: /evaluation
+sitemap: false
+---
+<meta http-equiv="refresh" content="0; url=/paper#evaluation">
+<p>Redirecting to <a href="/paper#evaluation">About the Paper — Evaluation</a>...</p>

--- a/_pages/paper.md
+++ b/_pages/paper.md
@@ -2,11 +2,6 @@
 title: "About the Paper"
 layout: single
 permalink: /paper
-redirect_from:
-  - /authors
-  - /research
-  - /evaluation
-  - /replication
 sidebar:
   nav: "guidelines"
 toc: true

--- a/_pages/replication.md
+++ b/_pages/replication.md
@@ -1,0 +1,6 @@
+---
+permalink: /replication
+sitemap: false
+---
+<meta http-equiv="refresh" content="0; url=/paper#replication-package">
+<p>Redirecting to <a href="/paper#replication-package">About the Paper — Replication Package</a>...</p>

--- a/_pages/research.md
+++ b/_pages/research.md
@@ -1,0 +1,6 @@
+---
+permalink: /research
+sitemap: false
+---
+<meta http-equiv="refresh" content="0; url=/paper#citation">
+<p>Redirecting to <a href="/paper#citation">About the Paper — Citation</a>...</p>


### PR DESCRIPTION
## What does this PR do?

Fixes the old URL redirects (/authors, /evaluation, /replication, /research) to target the specific section anchors on the consolidated /paper page instead of just redirecting to the top of the page.

Replaced the jekyll-redirect-from approach (which does not support fragment anchors) with lightweight HTML stub files using <meta http-equiv="refresh">:

- /authors → /paper#authors
- /evaluation → /paper#evaluation
- /replication → /paper#replication-package
- /research → /paper#citation

Each stub includes sitemap: false to keep the search index clean and a visible fallback link for browsers that don't follow meta-refresh. All internal links were already pointing to the correct /paper#anchor from the previous branch.

## Which guideline(s) does it affect?

General site update — no guideline content modified.

## Checklist

- [x] I followed the existing HTML structure and style (no new CSS files or frameworks).
- [x] The site renders correctly when I open the changed `.html` files locally.
- [x] My commit messages are descriptive (one concern per commit).