### PR TITLE
Restore Cronitor RUM tracking via custom head include

### DIFF
--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -1,0 +1,2 @@
+<!-- Cronitor Real User Monitoring -->
+<script async src="https://rum.cronitor.io/script.js" data-client-key="97d9d4d8389c85dd1e533df8355e7602"></script>


### PR DESCRIPTION
## What does this PR do?

Restores Cronitor Real User Monitoring (RUM) tracking, which was lost during the Jekyll migration. The old HTML files had the Cronitor snippet embedded directly; the Minimal Mistakes theme generates the <head> from its own templates, so the snippet was dropped.

The fix adds _includes/head/custom.html with the Cronitor script tag. Minimal Mistakes automatically includes this file in the
<head> of every generated page.

## Which guideline(s) does it affect?

General site update — no guideline content modified.

## Checklist

- [x] I followed the existing HTML structure and style (no new CSS files or frameworks).
- [x] The site renders correctly when I open the changed `.html` files locally.
- [x] My commit messages are descriptive (one concern per commit).